### PR TITLE
stack imbalance printing the hours elapsed

### DIFF
--- a/src/asm/asm.1.s
+++ b/src/asm/asm.1.s
@@ -601,7 +601,6 @@ calctime     php
              beq   :mins
              pea   0
              pha
-             pha
              pea   0
              pea   0
              _QADrawDec


### PR DESCRIPTION
probably never noticed because no assembly ever took that long.