### PR TITLE
Fix internal macro expansion

### DIFF
--- a/src/asm/asm.cond.s
+++ b/src/asm/asm.cond.s
@@ -1933,7 +1933,7 @@ expandint     php
               sta   printptr+2
 
               sep   $30
-* ldy #$00
+              ldy #$00
 
               lda   [fileptr]
               tax


### PR DESCRIPTION
I'm not sure why that line was commented out, but y has an undefined value at this point so it will read a random offset into the line.